### PR TITLE
Adding #include <vector> to utils.h file.

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 static const char* one_indent = "  ";
 extern int verbose;


### PR DESCRIPTION
When building the project with CMake I got the following error when compiling `utils.cpp.o` : 
```
/wrapit/src/utils.h:63:29: error: no template named 'vector' in namespace 'std'
```
Quickly added `#include <vectors>` at the top of the file to get rid of the error. 