### PR TITLE
add jlcxx::SafeCFunction to native types

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -1071,6 +1071,7 @@ CodeTree::register_type(const CXType& type){
     "std::vector<float>",
     "std::vector<double>",
     "std::vector<void*>",
+    "jlcxx::SafeCFunction",
   };
 
   bool usable;


### PR DESCRIPTION
This is needed to support callbacks from C++ to Julia