### PR TITLE
add `lib_prefix` option

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -100,6 +100,9 @@ export              = "member_functions"
 # with the command,
 # julia -e 'println(string.(vcat(names(Main),names(Base),names(Core))))'
 export_blacklist    = []
+
+# Shared library load prefix for the julia module.
+lib_prefix = "@__DIR__"
 ```
 
 ### Extra options for the header file code interpretation ([clang](https://clang.llvm.org/docs/UsersManual.html) options)

--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -767,7 +767,8 @@ CodeTree::generate_methods_of_templated_type_cxx(std::ostream& o,
 std::ostream& CodeTree::generate_jl(std::ostream& o,
                                     std::ostream& export_o,
                                     const std::string& module_name,
-                                    const std::string& shared_lib_basename) const{
+                                    const std::string& lib_prefix,
+                                    const std::string& lib_basename) const{
   o << "module " << module_name << "\n";
 
   bool first = true;
@@ -802,10 +803,14 @@ std::ostream& CodeTree::generate_jl(std::ostream& o,
   if(import_getindex_) o << "import Base.getindex\n";
   if(import_setindex_) o << "import Base.setindex!\n";
 
-  o <<  "\n"
-    "using CxxWrap\n"
-    "@wrapmodule(\"" << shared_lib_basename<< "\")\n"
-    "\n"
+  o <<  "\nusing CxxWrap\n";
+  if(lib_prefix.empty()) {
+    o << "@wrapmodule(\"" << lib_basename<< "\")\n";
+  }
+  else{
+    o << "@wrapmodule(joinpath(" << lib_prefix << ", \"" << lib_basename<< "\"))\n";
+  }
+  o << "\n"
     "function __init__()\n"
     "    @initcxx\n"
     "end\n";

--- a/src/CodeTree.h
+++ b/src/CodeTree.h
@@ -141,7 +141,8 @@ namespace codetree{
     std::ostream& generate_jl(std::ostream& o,
                               std::ostream& export_o,
                               const std::string& module_name,
-                              const std::string& shared_lib_name) const;
+                              const std::string& lib_prefix,
+                              const std::string& lib_basename) const;
 
     std::ostream& report(std::ostream& o);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,6 +139,7 @@ int main(int argc, char* argv[]){
     auto clang_features = read_vstring("clang_features");
     auto clang_opts     = read_vstring("clang_opts");
 
+    auto lib_prefix       = toml_config["lib_prefix"].value_or(std::string("@__DIR__"));
     auto lib_basename     = std::string("jl") + module_name;
     auto out_cpp_fname    = toml_config["out_cpp_fname"].value_or(std::string("jl") + module_name + ".cxx");
     auto out_h_fname      = toml_config["out_h_fname"].value_or(std::string("jl") + module_name + ".h");
@@ -318,7 +319,7 @@ int main(int argc, char* argv[]){
     tree.parse(out_h, out_h_fname);
     tree.preprocess();
     tree.generate_cxx(out_cpp);
-    tree.generate_jl(out_jl, out_export_jl, module_name, lib_basename);
+    tree.generate_jl(out_jl, out_export_jl, module_name, lib_prefix, lib_basename);
 
     tree.report(out_report);
   }


### PR DESCRIPTION
Fix https://github.com/grasph/wrapit/issues/18.

To recover the old behavior, use `lib_prefix = ""` in the config file.

With this fix, we can remove sourcing the `setup.sh` files in the tests (and replace `JULIA_LOAD_PATH` by a regular julian include statement `include("<generated_julia_module>.jl")`), so we could remove them from the repository and also remove the invocation from the `Makefile`s, thus simplifying the tests.

To illustrate my point, here is a single test diff:

```diff
diff --git a/test/TestAccessAndDelete/Makefile b/test/TestAccessAndDelete/Makefile
index 411f053..a71fb1e 100644
--- a/test/TestAccessAndDelete/Makefile
+++ b/test/TestAccessAndDelete/Makefile
@@ -40,7 +40,7 @@ echo_%:
         @echo $*=$($*)

 test:
-       $(MAKE) all && . ./setup.sh && julia run$(MODULE_NAME).jl
+       $(MAKE) all && julia run$(MODULE_NAME).jl


 -include $(addsuffix .d, $(basename $(CC_FILES)))
diff --git a/test/TestAccessAndDelete/runTestAccessAndDelete.jl b/test/TestAccessAndDelete/runTestAccessAndDelete.jl
index 2668679..108a9aa 100644
--- a/test/TestAccessAndDelete/runTestAccessAndDelete.jl
+++ b/test/TestAccessAndDelete/runTestAccessAndDelete.jl
@@ -1,4 +1,5 @@
-using TestAccessAndDelete
+include("TestAccessAndDelete.jl")
+using .TestAccessAndDelete
 using Test

 @testset "Access and deleted method test" begin
diff --git a/test/TestAccessAndDelete/setup.sh b/test/TestAccessAndDelete/setup.sh
deleted file mode 100644
index 829dbb7..0000000
--- a/test/TestAccessAndDelete/setup.sh
+++ /dev/null
@@ -1,3 +0,0 @@
-export JULIA_LOAD_PATH="@:@v#.#:@stdlib:`pwd`"
-export LD_LIBRARY_PATH="`pwd`"
-
```