### PR TITLE
Add support for integral template parameters

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -205,10 +205,15 @@ CodeTree::generate_cxx(std::ostream& o){
       if(!done){ //no-mirrored statement not yet generated
         if(verbose > 2) std::cerr << "Disable mirrored type for type " << type_name_cxx << "\n";
         if(c.template_parameter_combinations.size() > 0){
-          for(unsigned i = 0; i < c.template_parameter_combinations.size(); ++i){
-            indent(o, 1) << "template<> struct IsMirroredType<" << c.name(i)<< "> : std::false_type { };\n";
-            indent(o, 1) << "template<> struct DefaultConstructible<" << c.name(i)<< "> : std::false_type { };\n";
+          auto nparams = c.template_parameters.size();
+          std::vector<std::string> param_list;
+          for(decltype(nparams) i = 0; i < nparams; ++i){
+            param_list.emplace_back(c.template_parameter_types[i] + " " + c.template_parameters[i]);
           }
+          auto param_list1 = join(param_list, ", ");
+          auto param_list2 = join(c.template_parameters, ", ");
+          indent(o, 1) << "template<" << param_list1 << "> struct IsMirroredType<" << c.type_name << "<" << param_list2 << ">> : std::false_type { };\n";
+          indent(o, 1) << "template<" << param_list1 << "> struct DefaultConstructible<" << c.type_name << "<" << param_list2 << ">> : std::false_type { };\n";
         } else{
           indent(o, 1) << "template<> struct IsMirroredType<" << type_name_cxx << "> : std::false_type { };\n";
           indent(o, 1) << "template<> struct DefaultConstructible<" << type_name_cxx << "> : std::false_type { };\n";

--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -212,6 +212,23 @@ CodeTree::generate_cxx(std::ostream& o){
           }
           auto param_list1 = join(param_list, ", ");
           auto param_list2 = join(c.template_parameters, ", ");
+          o << "\n";
+          indent(o, 1) << "template<" << param_list1 << ">\n";
+          indent(o, 1) << "struct BuildParameterList<" << c.type_name << "<" << param_list2 << ">>\n";
+          indent(o, 1) << "{\n";
+          indent(o, 2) << "typedef ParameterList<";
+          const char* sep = "";
+          for(decltype(nparams) i = 0; i < nparams; ++i){
+            if (c.template_parameter_types[i] != "typename") {
+              o << sep << "std::integral_constant<" << c.template_parameter_types[i] << ", " << c.template_parameters[i] << ">";
+              sep = ", ";
+            } else {
+              o << sep << c.template_parameters[i];
+              sep = ", ";
+            }
+          }
+          o << "> type;\n";
+          indent(o,1) << "};\n\n";
           indent(o, 1) << "template<" << param_list1 << "> struct IsMirroredType<" << c.type_name << "<" << param_list2 << ">> : std::false_type { };\n";
           indent(o, 1) << "template<" << param_list1 << "> struct DefaultConstructible<" << c.type_name << "<" << param_list2 << ">> : std::false_type { };\n";
         } else{

--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -18,6 +18,7 @@
 #include "stdio.h"
 
 #include "FunctionWrapper.h"
+#include "libclang-ext.h"
 
 #include "utils.h"
 
@@ -1664,11 +1665,8 @@ bool CodeTree::add_type_specialization(TypeRcd* pTypeRcd, const CXType& type){
       combi.push_back(str(clang_getTypeSpelling(param)));
       param_types.push_back("typename");
     } else {
-      const auto *SD =
-        llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
-            static_cast<const clang::Decl *>(cursor.data[0]));
+      auto TA = get_IntegralTemplateArgument(cursor, i);
       using clang::TemplateArgument;
-      auto TA = SD->getTemplateArgs()[i];
       if (TA.getKind() == TemplateArgument::ArgKind::Integral){
         combi.push_back(std::to_string(TA.getAsIntegral().getSExtValue()));
         param_types.push_back(TA.getIntegralType().getAsString());

--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -22,6 +22,7 @@
 #include "utils.h"
 
 #include "clang/AST/Type.h" //FOR DEBUG
+#include "clang/AST/DeclTemplate.h"
 
 extern CXPrintingPolicy pp;
 
@@ -708,10 +709,12 @@ CodeTree::generate_methods_of_templated_type_cxx(std::ostream& o,
   buf << "t" << t.id << "_decl_methods";
   std::string decl_methods = buf.str();
 
-  auto param_list1 = join(myapply(t.template_parameters,
-                                  [](const std::string& x){
-                                    return std::string("typename ") + x;}),
-                          ", ");
+  auto nparams = t.template_parameters.size();
+  std::vector<std::string> param_list;
+  for(decltype(nparams) i = 0; i < nparams; ++i){
+    param_list.emplace_back(t.template_parameter_types[i] + " " + t.template_parameters[i]);
+  }
+  auto param_list1 = join(param_list, ", ");
   auto param_list2 = join(t.template_parameters, ", ");
 
   //  auto t1_decl_methods = []<typename T1, typename T2>(jlcxx::TypeWrapper<T1, T2> wrapped){
@@ -1158,7 +1161,7 @@ CodeTree::register_type(const CXType& type){
                                 << ". Number of template parameters: "
                                 << clang_Type_getNumTemplateArguments(clang_getCursorType(c))
                                 << ".\n";
-      add_type_specialization(&types_[i], c, clang_getCursorType(c));
+      add_type_specialization(&types_[i], clang_getCursorType(c));
       incomplete_types_.push_back(types_.size() - 1);
     } else if(type0.kind == CXType_Enum){
       auto it = std::find_if(enums_.begin(), enums_.end(),
@@ -1620,25 +1623,38 @@ CodeTree::visit_class_template_specialization(CXCursor cursor){
     add_type(specialized_cursor, /*check = */false);
     pTypeRcd = & types_.back();
   }
-  add_type_specialization(pTypeRcd, cursor, type);
+  add_type_specialization(pTypeRcd, type);
   pTypeRcd->to_wrap = true;
   pTypeRcd->template_parameters = get_template_parameters(specialized_cursor);
 }
 
-bool CodeTree::add_type_specialization(TypeRcd* pTypeRcd, const CXCursor& cursor, const CXType& type){
+bool CodeTree::add_type_specialization(TypeRcd* pTypeRcd, const CXType& type){
 
+  auto cursor = clang_getTypeDeclaration(type);
   auto nparams = clang_Type_getNumTemplateArguments(type);
   if(nparams <= 0) return false;
 
   std::vector<std::string> combi;
+  std::vector<std::string> param_types;
   for(decltype(nparams) i = 0; i < nparams; ++i){
-    const auto& param_kind = clang_Cursor_getTemplateArgumentKind(cursor, i);
-    if(param_kind == CXTemplateArgumentKind_Integral) {
-      combi.push_back(std::to_string(clang_Cursor_getTemplateArgumentValue(cursor, i)));
+    const auto& param = clang_Type_getTemplateArgumentAsType(type, i);
+    if (param.kind != CXType_Invalid) {
+      combi.push_back(str(clang_getTypeSpelling(param)));
+      param_types.push_back("typename");
     } else {
-      const auto& param_type = clang_Type_getTemplateArgumentAsType(type, i);
-      //FIXME: add support for value template argument
-      combi.push_back(str(clang_getTypeSpelling(param_type)));
+      const auto *SD =
+        llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+            static_cast<const clang::Decl *>(cursor.data[0]));
+      using clang::TemplateArgument;
+      auto TA = SD->getTemplateArgs()[i];
+      if (TA.getKind() == TemplateArgument::ArgKind::Integral){
+        combi.push_back(std::to_string(TA.getAsIntegral().getSExtValue()));
+        param_types.push_back(TA.getIntegralType().getAsString());
+      } else {
+        // The "FIXME" is a message for the user; highlighting that the template argument
+        // is neither a type or an integral parameter
+        combi.push_back("/* FIXME */");
+      }
     }
   }
 
@@ -1647,6 +1663,7 @@ bool CodeTree::add_type_specialization(TypeRcd* pTypeRcd, const CXCursor& cursor
                                    combi)){
     combi_list.push_back(combi);
   }
+  pTypeRcd->template_parameter_types = param_types;
 
   return true;
 }

--- a/src/CodeTree.h
+++ b/src/CodeTree.h
@@ -224,7 +224,7 @@ namespace codetree{
     CXToken* next_token(CXSourceLocation loc) const;
     CXSourceRange function_decl_range(const CXCursor& cursor) const;
 
-    bool add_type_specialization(TypeRcd* pTypeRcd, const CXCursor& cursor, const CXType& type);
+    bool add_type_specialization(TypeRcd* pTypeRcd, const CXType& type);
 
     //Finds the definition of a type or the underlying type in case
     //of a pointer or reference. For a templated type,

--- a/src/CodeTree.h
+++ b/src/CodeTree.h
@@ -224,7 +224,7 @@ namespace codetree{
     CXToken* next_token(CXSourceLocation loc) const;
     CXSourceRange function_decl_range(const CXCursor& cursor) const;
 
-    bool add_type_specialization(TypeRcd* pTypeRcd,  const CXType& type);
+    bool add_type_specialization(TypeRcd* pTypeRcd, const CXCursor& cursor, const CXType& type);
 
     //Finds the definition of a type or the underlying type in case
     //of a pointer or reference. For a templated type,

--- a/src/TypeRcd.h
+++ b/src/TypeRcd.h
@@ -14,6 +14,7 @@ struct TypeRcd {
   std::vector<CXCursor> fields;
   std::vector<CXCursor> typedefs;
   std::vector<std::string> template_parameters;
+  std::vector<std::string> template_parameter_types;
   std::vector<std::vector<std::string> > template_parameter_combinations;
   bool to_wrap;
   int id;

--- a/src/libclang-ext.cpp
+++ b/src/libclang-ext.cpp
@@ -225,3 +225,11 @@ get_template_parameters(CXCursor cursor){
   }
   return res;
 }
+
+const clang::TemplateArgument & get_IntegralTemplateArgument(CXCursor cursor, int i) {
+  const auto *SD =
+    llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(
+        static_cast<const clang::Decl *>(cursor.data[0]));
+  return SD->getTemplateArgs()[i];
+
+}

--- a/src/libclang-ext.h
+++ b/src/libclang-ext.h
@@ -8,6 +8,7 @@
 #define LIBCLANG_EXT_H
 
 #include <clang-c/Index.h>
+#include "clang/AST/Type.h"
 #include <string>
 
 std::string fully_qualified_name(CXCursor c);
@@ -21,5 +22,7 @@ CXType remove_non_builtin_qualifiers(CXType& type);
 CXType base_type(CXType type);
 
 std::string remove_cv(const std::string& type_name);
+
+const clang::TemplateArgument & get_IntegralTemplateArgument(CXCursor cursor, int i);
 
 #endif //LIBCLANG_EXT_H not defined


### PR DESCRIPTION
Integral type parameters require special handling in clang to extract/reproduce, and CxxWrap needs a specialization of `BuildParameterList` for the parametric type with the integral parameters.

I don't know if this will work for dependent(?) integral type parameters, along the lines of `MyClass<typename T, T I>`.
