### PR TITLE
Avoid capturing types in the template lambda

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -589,10 +589,10 @@ CodeTree::method_cxx_decl(std::ostream& o, const MethodRcd& method,
 
   bool new_override_base = wrapper.override_base();
   if(override_base_ && !new_override_base){
-    indent(o << "\n", 1) << "types.unset_override_module();\n";
+    indent(o << "\n", 1) << varname << ".module().unset_override_module();\n";
     override_base_ = new_override_base;
   } else if(!override_base_ && new_override_base){
-    indent(o, 1) << "types.set_override_module(jl_base_module);\n";
+    indent(o, 1) << varname << ".module().set_override_module(jl_base_module);\n";
     override_base_ = new_override_base;
   }
   o << "\n";


### PR DESCRIPTION
This avoids capturing the `types` variable (which currently causes the compiler to complain), and follows the example in the [libcxxwrap-julia repo](https://github.com/JuliaInterop/libcxxwrap-julia/blob/main/examples/parametric.cpp). Alternately, we could change the lambda definition to allow implicit captures with `[&]` (I think?), but that doesn't seem to be necessary.
