### PR TITLE
Fix enum scoping on Julia's side.

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -2296,7 +2296,8 @@ CodeTree::get_prefix(const std::string& type_name) const{
 std::ostream&
 CodeTree::generate_enum_cxx(std::ostream& o, CXCursor cursor){
 
-  bool anonymous_enum = clang_Cursor_isAnonymous(cursor);
+  const bool anonymous_enum = clang_Cursor_isAnonymous(cursor);
+  const bool scoped_enum = clang_EnumDecl_isScoped(cursor);
 
   std::string type_name;
   const auto& type = clang_getCursorType(cursor);
@@ -2313,7 +2314,7 @@ CodeTree::generate_enum_cxx(std::ostream& o, CXCursor cursor){
 
   //extract prefix from a string formatted as 'prefix::type_name':
   auto prefix_cxx = get_prefix(type_name);
-  auto prefix_jl = jl_type_name(prefix_cxx);
+  auto prefix_jl = scoped_enum ? jl_type_name(type_name)+"!" : jl_type_name(prefix_cxx);
 
   if(prefix_cxx.size() > 2){
     const auto& clazz = prefix_cxx.substr(0, prefix_cxx.size() - 2);
@@ -2346,7 +2347,7 @@ CodeTree::generate_enum_cxx(std::ostream& o, CXCursor cursor){
 
   for(const auto& value: values){
     std::string value_cpp;
-    if(clang_EnumDecl_isScoped(cursor)){
+    if(scoped_enum){
       value_cpp = type_name + "::" + value;
     } else{
       value_cpp = prefix_cxx + value;

--- a/test/TestEnum/A.h
+++ b/test/TestEnum/A.h
@@ -1,0 +1,14 @@
+enum class A {
+   C = 1,
+   D = 2
+};
+
+enum class B {
+   C = 3,
+   D = 4
+};
+
+enum E {
+  E1 = 5,
+  E2 = 6
+};

--- a/test/TestEnum/Makefile
+++ b/test/TestEnum/Makefile
@@ -1,0 +1,7 @@
+#CXXFLAGS += -DVERBOSE_IMPORT #To enable the verbose mode of the libray loading
+#CXXFLAGS += -Wall -O0 -g     #To compile with debugger infomation
+
+MODULE_NAME=TestEnum
+
+-include ../make.rules
+

--- a/test/TestEnum/TestEnum.wit
+++ b/test/TestEnum/TestEnum.wit
@@ -1,0 +1,14 @@
+module_name="TestEnum"
+
+input = [ "A.h" ]
+		  
+include_dirs = [ "." ]
+
+cxx-std = "c++17"
+
+auto_veto = false
+
+export = "all"
+
+# all generated code in a single file:
+n_classes_per_file = 0

--- a/test/TestEnum/runTestEnum.jl
+++ b/test/TestEnum/runTestEnum.jl
@@ -1,0 +1,22 @@
+using Test
+using TestEnum
+using CxxWrap
+
+@testset "Enums" begin
+    @test typeof(TestEnum.A) == DataType
+    @test TestEnum.A!C == 1
+    @test TestEnum.A!D == 2
+
+    @test typeof(TestEnum.B) == DataType
+    @test TestEnum.B!C == 3
+    @test TestEnum.B!D == 4
+
+    @test typeof(TestEnum.E) == DataType
+    @test TestEnum.E1 == 5
+    @test TestEnum.E2 == 6
+
+    @test_throws UndefVarError TestEnum.C
+    @test_throws UndefVarError TestEnum.D
+    @test_throws UndefVarError TestEnum.E!E1
+    @test_throws UndefVarError TestEnum.E!E2
+end

--- a/test/TestEnum/setup.sh
+++ b/test/TestEnum/setup.sh
@@ -1,0 +1,3 @@
+export JULIA_LOAD_PATH="@:@v#.#:@stdlib:`pwd`/TestEnum/src"
+export LD_LIBRARY_PATH="`pwd`/libTestEnum"
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
 using Test
-tests = [ "TestCtorDefVal"  "TestAccessAndDelete" "TestNoFinalizer" "TestInheritance"  "TestPropagation"  "TestTemplate1"  "TestTemplate2"  "TestVarField" "TestStdString" ]
+tests = [ "TestCtorDefVal"  "TestAccessAndDelete" "TestNoFinalizer" "TestInheritance"  "TestPropagation"  "TestTemplate1"  "TestTemplate2"  "TestVarField" "TestStdString" "TestEnum" ]
 
 @testset verbose=true "Tests" begin
     for t in tests


### PR DESCRIPTION
On master the generated Julia names do not follow the C++ scope. This can lead to naming conflicts in codegen. MWE

```cpp
enum class A {
   C
};

enum class B {
   C
};
```
would lead to a conflicting method `C`.

This PR fixes this issue by following the C++ scoping rule.