### PR TITLE
Improve CMakeLists.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ test/myruntests.jl
 test/not_yet_working_tests/
 test/toto
 
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,56 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cxxopts)
 
-find_package(Clang REQUIRED CONFIG)
-find_package(LLVM REQUIRED CONFIG)
-include_directories(${CLANG_INCLUDE_DIRS})
-if(DEFINED CLANG_RESOURCE_DIR AND NOT CLANG_RESOURCE_DIR STREQUAL "")
-   set(CLANG_RESOURCE_DIR_PATH "${LLVM_TOOLS_BINARY_DIR}/${CLANG_RESOURCE_DIR}")
-else()
-   set(CLANG_RESOURCE_DIR_PATH "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION_MAJOR}")
-endif()
+# CLANG_JLL is used by Binary Builder
+# For building the package stand-alone it is not used
+if (NOT CLANG_JLL)
+  find_package(Clang REQUIRED CONFIG)
+  find_package(LLVM REQUIRED CONFIG)
+  include_directories(${CLANG_INCLUDE_DIRS})
+  if(DEFINED CLANG_RESOURCE_DIR AND NOT CLANG_RESOURCE_DIR STREQUAL "")
+    set(CLANG_RESOURCE_DIR_PATH "${LLVM_TOOLS_BINARY_DIR}/${CLANG_RESOURCE_DIR}")
+  else()
+    set(CLANG_RESOURCE_DIR_PATH "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION_MAJOR}")
+  endif()
 
-execute_process(COMMAND "${LLVM_TOOLS_BINARY_DIR}/clang" -print-resource-dir
-               OUTPUT_VARIABLE CLANG_RESOURCE_DIR_DISCOVERED_PATH
-               OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND "${LLVM_TOOLS_BINARY_DIR}/clang" -print-resource-dir
+                OUTPUT_VARIABLE CLANG_RESOURCE_DIR_DISCOVERED_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+else() # Using Clang_jll
+  # Clang_jll package lacks the Clang Cmake conifiguration file,
+  # Set the clang dependency by  hand:
+  set(STATIC_LIBS clangAST clangLex clangBasic clangDriver)
+  foreach(static_lib IN LISTS STATIC_LIBS) 
+      add_library(${static_lib} STATIC IMPORTED)
+      set_property(TARGET ${static_lib} PROPERTY
+                  IMPORTED_LOCATION "${CMAKE_INSTALL_PREFIX}/lib/lib${static_lib}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  endforeach()
+
+  set(SHARED_LIBS libclang LLVM)
+  foreach(shared_lib IN LISTS SHARED_LIBS) 
+      add_library(${shared_lib} SHARED IMPORTED)
+      set(lib_path "${CMAKE_INSTALL_PREFIX}/lib/lib${shared_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      string(REPLACE liblib lib lib_path ${lib_path})
+      set_property(TARGET ${shared_lib} PROPERTY
+                  IMPORTED_LOCATION ${lib_path})
+  endforeach()
+
+  set_target_properties(clangBasic PROPERTIES
+                        INTERFACE_LINK_LIBRARIES "LLVM")
+
+  set_target_properties(clangLex PROPERTIES
+                        INTERFACE_LINK_LIBRARIES "clangBasic;LLVM")
+
+  set_target_properties(clangAST PROPERTIES
+                        INTERFACE_LINK_LIBRARIES "clangBasic;clangLex;LLVM")
+
+  if(NOT ($ENV{target} MATCHES "darwin"))
+    execute_process(COMMAND /bin/sh -c "nm -C \$prefix/lib/libclang.so | grep -q abi:cxx11" RESULT_VARIABLE rc)
+    if(NOT (rc EQUAL 0)) #libclang.so compiled with cxx03 ABI
+        add_compile_options(-D_GLIBCXX_USE_CXX11_ABI=0)
+    endif()
+  endif()
+endif()
 
 set(CLANG_RESOURCE_DIR_FULLPATH "${CLANG_RESOURCE_DIR_DISCOVERED_PATH}" CACHE
     FILEPATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Copyright (C) 2021 Philippe Gras CEA/Irfu <philippe.gras@cern.ch>
 
-cmake_minimum_required (VERSION 3.0)
+cmake_minimum_required (VERSION 3.12)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 project (CxxWrapGen)
@@ -9,7 +9,7 @@ include(FetchContent)
 
 find_package(Git)
 
-#Package to parse command line options
+# Package to parse command line options
 FetchContent_Declare(
     cxxopts
     GIT_REPOSITORY https://github.com/jarro2783/cxxopts.git
@@ -17,57 +17,19 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(cxxopts)
 
-set(SEARCH_CLANG_CMAKE TRUE
-    CACHE BOOL "If true use the Clang cmake configuration files found on the system.")
-
-if(NOT CLANG_JLL)
-   find_package(Clang REQUIRED CONFIG)
-   include_directories(${CLANG_INCLUDE_DIRS})
-   if(DEFINED CLANG_RESOURCE_DIR AND NOT CLANG_RESOURCE_DIR STREQUAL "")
-     set(CLANG_RESOURCE_DIR_PATH "${LLVM_TOOLS_BINARY_DIR}/${CLANG_RESOURCE_DIR}")
-   else()
-     set(CLANG_RESOURCE_DIR_PATH "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION_MAJOR}")
-   endif()
-
-  execute_process(COMMAND "${LLVM_TOOLS_BINARY_DIR}/clang" -print-resource-dir
-                  OUTPUT_VARIABLE CLANG_RESOURCE_DIR_DISCOVERED_PATH
-                  OUTPUT_STRIP_TRAILING_WHITESPACE)
-                
-else() #Using Clang_jll
-   #Clang_jll package lacks the Clang Cmake conifiguration file,
-   #Set the clang dependency by  hand:
-   set(STATIC_LIBS clangAST clangLex clangBasic clangDriver)
-   foreach(static_lib IN LISTS STATIC_LIBS) 
-       add_library(${static_lib} STATIC IMPORTED)
-       set_property(TARGET ${static_lib} PROPERTY
-                    IMPORTED_LOCATION "${CMAKE_INSTALL_PREFIX}/lib/lib${static_lib}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-   endforeach()
-   
-   set(SHARED_LIBS libclang LLVM)
-   foreach(shared_lib IN LISTS SHARED_LIBS) 
-       add_library(${shared_lib} SHARED IMPORTED)
-       set(lib_path "${CMAKE_INSTALL_PREFIX}/lib/lib${shared_lib}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-       string(REPLACE liblib lib lib_path ${lib_path})
-       set_property(TARGET ${shared_lib} PROPERTY
-                    IMPORTED_LOCATION ${lib_path})
-   endforeach()
-   
-   set_target_properties(clangBasic PROPERTIES
-                         INTERFACE_LINK_LIBRARIES "LLVM")
-   
-   set_target_properties(clangLex PROPERTIES
-                         INTERFACE_LINK_LIBRARIES "clangBasic;LLVM")
-   
-   set_target_properties(clangAST PROPERTIES
-                         INTERFACE_LINK_LIBRARIES "clangBasic;clangLex;LLVM")
-
-   if(NOT ($ENV{target} MATCHES "darwin"))
-      execute_process(COMMAND /bin/sh -c "nm -C \$prefix/lib/libclang.so | grep -q abi:cxx11" RESULT_VARIABLE rc)
-      if(NOT (rc EQUAL 0)) #libclang.so compiled with cxx03 ABI
-         add_compile_options(-D_GLIBCXX_USE_CXX11_ABI=0)
-      endif()
-    endif()
+find_package(Clang REQUIRED CONFIG)
+find_package(LLVM REQUIRED CONFIG)
+llvm_map_components_to_libnames(llvm_libs core)
+include_directories(${CLANG_INCLUDE_DIRS})
+if(DEFINED CLANG_RESOURCE_DIR AND NOT CLANG_RESOURCE_DIR STREQUAL "")
+   set(CLANG_RESOURCE_DIR_PATH "${LLVM_TOOLS_BINARY_DIR}/${CLANG_RESOURCE_DIR}")
+else()
+   set(CLANG_RESOURCE_DIR_PATH "${LLVM_LIBRARY_DIR}/clang/${CLANG_VERSION_MAJOR}")
 endif()
+
+execute_process(COMMAND "${LLVM_TOOLS_BINARY_DIR}/clang" -print-resource-dir
+               OUTPUT_VARIABLE CLANG_RESOURCE_DIR_DISCOVERED_PATH
+               OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 set(CLANG_RESOURCE_DIR_FULLPATH "${CLANG_RESOURCE_DIR_DISCOVERED_PATH}" CACHE
     FILEPATH
@@ -113,7 +75,7 @@ add_executable(wrapit
 
 add_dependencies(wrapit version)
 
-target_link_libraries(wrapit PRIVATE libclang clangAST clangDriver cxxopts dl)
+target_link_libraries(wrapit PRIVATE libclang clang-cpp ${llvm_libs} cxxopts dl)
 set_target_properties(wrapit PROPERTIES
   CXX_STANDARD 17
   OUTPUT_NAME wrapit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ FetchContent_MakeAvailable(cxxopts)
 
 find_package(Clang REQUIRED CONFIG)
 find_package(LLVM REQUIRED CONFIG)
-llvm_map_components_to_libnames(llvm_libs core)
 include_directories(${CLANG_INCLUDE_DIRS})
 if(DEFINED CLANG_RESOURCE_DIR AND NOT CLANG_RESOURCE_DIR STREQUAL "")
    set(CLANG_RESOURCE_DIR_PATH "${LLVM_TOOLS_BINARY_DIR}/${CLANG_RESOURCE_DIR}")
@@ -75,7 +74,7 @@ add_executable(wrapit
 
 add_dependencies(wrapit version)
 
-target_link_libraries(wrapit PRIVATE libclang clang-cpp ${llvm_libs} cxxopts dl)
+target_link_libraries(wrapit PRIVATE libclang clang-cpp LLVM cxxopts dl)
 set_target_properties(wrapit PROPERTIES
   CXX_STANDARD 17
   OUTPUT_NAME wrapit

--- a/README.md
+++ b/README.md
@@ -29,21 +29,24 @@ The file config.toml contains the parameters for the generation, in particular t
 
   * Software to be present on the system before running `cmake`:
     * libclang: packages `clang-13` and `libclang-13-dev` on Debian
+    * libclang: packages `llvm`, `llvm-devel`, `clang`, `clang-devel` on Alma/Rocky/RHEL
     * On MacOS, you can install `llvm/clang` with brew running the command `brew install llvm` from a terminal
   * Software will be downloaded  by the `cmake` command:
     * [tomlplusplus](https://github.com/marzer/tomlplusplus.git)
 
 ### Build
 
-  * create a build directory
-  ```
-  mkdir build
-  cd build
-  ```
-  * run `cmake ..` in the  build directory. On MacOS, add the prefix of the llvm/clang installation `-DCMAKE_PREFIX_PATH=/usr/local/opt/llvm`  
-  * run `make -j4`
+Build using cmake in the "usual" way. e.g.,
 
-The `make` command will produce the executable `wrapit`. Run `make install` if you'd like to copy it into the system `bin` directory.
+```sh
+mkdir build && cd build
+cmake -S .. -B . -DCMAKE_INSTALL_PREFIX=/opt
+cmake --build .
+```
+
+On OS X it is necessary to add the prefix of the clang/llvm installation, `-DCMAKE_PREFIX_PATH=/opt/homebrew/Cellar/llvm/LLVM_VERSION`
+
+The build process will produce the `wrapit` executable. Install it with `cmake --build . --target install`.
 
 ## A simple example
 


### PR DESCRIPTION
This is a large change to CMakeLists, with the headline that it fixes the compilation of wrapit on AlmaLinux9.

Simplify the configuration to use the system clang/llvm installation (use of CLANG_JLL from the Julia installation seems very fragile and I could not get it to work properly)

Use the "unified" new clang targets (libclang clang-cpp) instead of the deprecated split libraries.

Use recommended llvm recipe for the code llvm libraries.

Update CMake minimum version to 3.12, which throws no warnings on configuration with the latest releases (released 5 years ago, so not onerous!).

Update README with instructions for Alma and updated instructions for OS X brew install location.