### PR TITLE
stat.st_atim does not exists on macOS

### DIFF
--- a/src/FileTimeRestorer.cpp
+++ b/src/FileTimeRestorer.cpp
@@ -10,6 +10,10 @@
 
 extern int verbose;
 
+#if defined(__APPLE__)
+  #define st_atim st_atimespec
+#endif
+
 FileTimeRestorer::FileTimeRestorer(const std::string& fname, int nskiplines):
   fname_(fname), nskiplines_(nskiplines){
   md5sum(md5_, fname_, nskiplines_);


### PR DESCRIPTION
While building main branch I get the following warnings and errors on MacOS with MacOSX14.2.sdk
```
...
/Users/mato/Development/wrapit/src/md5sum.cpp:18:3: warning: 'MD5_Init' is deprecated [-Wdeprecated-declarations]
  MD5_Init(&md5Context);
  ^
/opt/homebrew/include/openssl/md5.h:49:1: note: 'MD5_Init' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int MD5_Init(MD5_CTX *c);
^
/opt/homebrew/include/openssl/macros.h:193:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/opt/homebrew/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
/Users/mato/Development/wrapit/src/md5sum.cpp:22:5: warning: 'MD5_Update' is deprecated [-Wdeprecated-declarations]
    MD5_Update(&md5Context, buf, file.gcount());
    ^
/opt/homebrew/include/openssl/md5.h:50:1: note: 'MD5_Update' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int MD5_Update(MD5_CTX *c, const void *data, size_t len);
^
/opt/homebrew/include/openssl/macros.h:193:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/opt/homebrew/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
/Users/mato/Development/wrapit/src/md5sum.cpp:25:3: warning: 'MD5_Final' is deprecated [-Wdeprecated-declarations]
  MD5_Final(md5.data(), &md5Context);
  ^
/opt/homebrew/include/openssl/md5.h:51:1: note: 'MD5_Final' has been explicitly marked deprecated here
OSSL_DEPRECATEDIN_3_0 int MD5_Final(unsigned char *md, MD5_CTX *c);
^
/opt/homebrew/include/openssl/macros.h:193:49: note: expanded from macro 'OSSL_DEPRECATEDIN_3_0'
#   define OSSL_DEPRECATEDIN_3_0                OSSL_DEPRECATED(3.0)
                                                ^
/opt/homebrew/include/openssl/macros.h:62:52: note: expanded from macro 'OSSL_DEPRECATED'
#     define OSSL_DEPRECATED(since) __attribute__((deprecated))
                                                   ^
3 warnings generated.
[ 75%] Building CXX object CMakeFiles/wrapit.dir/src/FileTimeRestorer.cpp.o
/Users/mato/Development/wrapit/src/FileTimeRestorer.cpp:30:53: error: no member named 'st_atim' in 'stat'
    utimensat(AT_FDCWD, fname_.c_str(), &(filestat_.st_atim), 0);
                                          ~~~~~~~~~ ^
1 error generated.
make[2]: *** [CMakeFiles/wrapit.dir/src/FileTimeRestorer.cpp.o] Error 1
make[1]: *** [CMakeFiles/wrapit.dir/all] Error 2
make: *** [all] Error 2
```
