### PR TITLE
Add support for enum forward declarations

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -2121,7 +2121,7 @@ bool CodeTree::add_type_specialization(TypeRcd* pTypeRcd, const CXType& type){
 bool CodeTree::isAForwardDeclaration(CXCursor cursor) const{
   const auto& kind = clang_getCursorKind(cursor);
 
-  auto rc =  (kind == CXCursor_ClassDecl || kind == CXCursor_StructDecl)
+  auto rc =  (kind == CXCursor_ClassDecl || kind == CXCursor_StructDecl || kind == CXCursor_EnumDecl)
     && !clang_equalCursors(clang_getCursorDefinition(cursor), cursor);
 
   const auto& special = clang_getSpecializedCursorTemplate(cursor);
@@ -2234,7 +2234,7 @@ CXChildVisitResult CodeTree::visit(CXCursor cursor, CXCursor parent,
     tree.visit_class(cursor);
   } else if(kind == CXCursor_FunctionDecl){
     tree.visit_global_function(cursor);
-  } else if(kind == CXCursor_EnumDecl){
+  } else if(kind == CXCursor_EnumDecl && !tree.isAForwardDeclaration(cursor)){
     tree.visit_enum(cursor);
   } else if(kind == CXCursor_TypedefDecl){
     //  tree.visit_typedef(cursor);

--- a/test/TestEnum/A.h
+++ b/test/TestEnum/A.h
@@ -12,3 +12,12 @@ enum E {
   E1 = 5,
   E2 = 6
 };
+
+// Only the definition should create a binding, otherwise a duplicate will be
+// created for the forward declaration which will cause an error during
+// precompilation.
+enum ForwardDecl : int;
+enum ForwardDecl : int {
+    X = 1,
+    Y = 2
+};


### PR DESCRIPTION
These will otherwise create duplicate bindings.