### PR TITLE
Add support for CxxWrap 0.16

### DIFF
--- a/src/cxxwrap_version.cpp
+++ b/src/cxxwrap_version.cpp
@@ -5,10 +5,11 @@
 //v0.10.0 (not used by any CxxWrap release),
 //v0.11.0 (CxxWrap v0.14.0),
 //v0.12.0 (CxxWrap v0.15.0)
+//v0.13.0 (not breaking, see https://github.com/JuliaInterop/CxxWrap.jl/releases/tag/v0.16.0)
 std::tuple<long, long> version_libcxxwrap_bounds(long cxxwrap_version){
   if(cxxwrap_version < cxxwrap_v0_15){
     return std::tuple<long, long>(11*1000, 12*1000);
   } else{
-    return std::tuple<long, long>(12*1000, 13*1000);
+    return std::tuple<long, long>(12*1000, 14*1000);
   }
 }

--- a/src/cxxwrap_version.h
+++ b/src/cxxwrap_version.h
@@ -1,9 +1,9 @@
 #include <tuple>
 
 //Default value for the cxxwrap_version config parameter
-static const char* default_cxxwrap_version = "0.15.0";
+static const char* default_cxxwrap_version = "0.16.0";
 
-static const char* supported_cxxwrap_versions = "0.14.x, 0.15.x";
+static const char* supported_cxxwrap_versions = "0.14.x, 0.15.x, 0.16.x";
 
 static int cxxwrap_v0_15 = 15 * 1000; //v0.15
 


### PR DESCRIPTION
I believe this is backwards compatible apart from needing a rebuild, so adding support isn't too tricky :crossed_fingers: 