### PR TITLE
Use the git commit hash as the version if not on a tag

### DIFF
--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,1 +1,1 @@
-const char* version = "@GIT_TAG@";
+const char* version = "@GIT_REF@";

--- a/version.cmake
+++ b/version.cmake
@@ -1,7 +1,14 @@
 execute_process(COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --match "v*"
                 WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-                OUTPUT_VARIABLE GIT_TAG
+                OUTPUT_VARIABLE GIT_REF
                 OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
 
-configure_file(${SRC} ${DST} @ONLY)
+# If we're not on a tag, use the commit hash
+if(NOT GIT_REF)
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty
+                  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+                  OUTPUT_VARIABLE GIT_REF
+                  OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+endif()
 
+configure_file(${SRC} ${DST} @ONLY)


### PR DESCRIPTION
This is a bit nicer than just leaving it empty.