### PR TITLE
Recognize `jlcxx::Array` and `jlcxx::ArrayRef` as natively supported

### DIFF
--- a/src/CodeTree.cpp
+++ b/src/CodeTree.cpp
@@ -2974,6 +2974,8 @@ bool CodeTree::is_natively_supported(const std::string& type_fqn,
     {"std::vector", 1},
     {"std::valarray", 1},
     {"jlcxx::SafeCFunction", 0},
+    {"jlcxx::Array", 1},
+    {"jlcxx::ArrayRef", 2},
     {"std::shared_ptr", 1},
     {"std::unique_ptr", 1},
     {"std::weak_ptr", 1}


### PR DESCRIPTION
~~This is a speculative attempt to add an override to the `auto_veto` feature. It's useful in cases where there are many functions that shouldn't be wrapped that are correctly vetoed by `auto_veto`, but there's a few that should be wrapped anyway.~~

~~My motivation is that there there's a function I'm defining in a custom header that returns a `jlcxx::Array`. CxxWrap already supports this so nothing extra is required, but wrapit will create wrappers for `jlcxx::Array` anyway and insert them into the module. I don't want this to happen so I tried adding `jlcxx::Array` to the veto list, but because of `auto_veto` my function was removed as well. And I don't want to disable `auto_veto` because there are many dozens of functions that it correctly removes. With this PR I can set `veto_overrides_list = "veto_overrides.txt"` and allow only that one function to get through `auto_veto`.~~

An alternative approach would be to add built-in support for the `jlcxx::Array`/`jlcxx::ArrayRef` types, but I figured this is more general so it might be more useful. What do you think?